### PR TITLE
VkDevice aliases a pointer type. Remove ref qualifier.

### DIFF
--- a/lib/descriptor.cxx
+++ b/lib/descriptor.cxx
@@ -11,7 +11,7 @@
  * - uboLayoutBinding: Binds the uniform buffer to the vertex and fragment shader.
  * - samplerLayoutBinding: Binds the image sampler to the fragment shader. This binding is set as
  * VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT. **/
-void OttDescriptor::createObjectDescriptorSetLayout(VkDevice& device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts)
+void OttDescriptor::createObjectDescriptorSetLayout(VkDevice device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts)
 {
     constexpr VkDescriptorSetLayoutBinding uboLayoutBinding {
                                             .binding         = 0,
@@ -59,7 +59,7 @@ void OttDescriptor::createObjectDescriptorSetLayout(VkDevice& device, std::vecto
 /** Creates a descriptor set for the Grid rendering pipeline.
  *  - gridBinding: We need an Uniform Buffer to pass the camera position to the shader
  *  for the grid falloff. Vertex buffer and Fragment shader are dealt internally. **/
-void OttDescriptor::createGridDescriptorSetLayout(VkDevice& device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts)
+void OttDescriptor::createGridDescriptorSetLayout(VkDevice device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts)
 {
     constexpr VkDescriptorSetLayoutBinding gridBinding {
         .binding         = 0,
@@ -90,7 +90,7 @@ void OttDescriptor::createGridDescriptorSetLayout(VkDevice& device, std::vector<
 //----------------------------------------------------------------------------
 /** \param device: Application side instantiated device.
  *  \param descriptor_pool: Application side instantiated descriptor pool handle. **/
-void OttDescriptor::createDescriptorPool(VkDevice& device, VkDescriptorPool& descriptor_pool)
+void OttDescriptor::createDescriptorPool(VkDevice device, VkDescriptorPool& descriptor_pool)
 {
     std::array poolSizes   = {
         VkDescriptorPoolSize {

--- a/lib/include/descriptor.h
+++ b/lib/include/descriptor.h
@@ -23,9 +23,9 @@ struct UniformBufferObject {
 
 namespace OttDescriptor
 {
-    void createObjectDescriptorSetLayout    (VkDevice& device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts);
-    void createGridDescriptorSetLayout      (VkDevice& device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts);
-    void createDescriptorPool               (VkDevice& device, VkDescriptorPool& descriptor_pool);
+    void createObjectDescriptorSetLayout    (VkDevice device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts);
+    void createGridDescriptorSetLayout      (VkDevice device, std::vector<VkDescriptorSetLayout>& descriptor_set_layouts);
+    void createDescriptorPool               (VkDevice device, VkDescriptorPool& descriptor_pool);
     
     void createDescriptorSets               (const std::vector<VkDescriptorSetLayout>& descriptor_set_layouts,
                                             std::vector<VkDescriptorSet>& descriptor_sets,


### PR DESCRIPTION
We don't need to take these pointers by reference.